### PR TITLE
Timeout requests to local session after 100ms.

### DIFF
--- a/include/xpedite/common/LeasedPtr.H
+++ b/include/xpedite/common/LeasedPtr.H
@@ -1,0 +1,124 @@
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// LeasedPtr - a SPSC wait free data structure for sharing a resource between two threads.
+//
+// It has a clear ownership semantics, allowing the consumer to lease the pointer from the producer.
+//
+// Once the consumer has successfully borrowed the resource, the producer will know not to deallocate
+// the resource until the consumer has returned the lease.
+//
+// If the consumer takes too long to return the resource, the producer can release the ownership.
+// The LeasedPtr will ensure the consumer knows it now owns the resource and is responsible for deallocation.
+//
+// Author: Marcin Dlugajczyk, Morgan Stanley
+//
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+#include <atomic>
+#include <cassert>
+#include <memory>
+
+namespace xpedite { namespace common {
+
+  template<typename T>
+  class LeasedPtr
+  {
+    // The LeasedPtr can be in one of 5 states.
+    // Dormant - the class is empty, and is ready to accept `provision` request from the producer.
+    // Provisioned - producer has stored a pointer, and it hasn't been leased by the consumer yet.
+    // Leased - the consumer has leased the ptr.
+    // Revoked - the producer has relenquished the ownership of the pointer.
+    // Returned - the consumer has returned the leased ptr.
+    enum class State {
+      Dormant,
+      Provisioned,
+      Leased,
+      Revoked,
+      Returned
+    };
+    std::unique_ptr<T> _ptr{nullptr};
+    std::atomic<State> _state{State::Dormant};
+
+  public:
+    LeasedPtr() noexcept = default;
+    explicit LeasedPtr(T *ptr_) noexcept : _ptr{ptr_} {}
+    ~LeasedPtr() = default;
+    LeasedPtr<T>(LeasedPtr<T> &other) = delete;
+    LeasedPtr<T>(LeasedPtr<T> &&other) = delete;
+    LeasedPtr<T>& operator=(LeasedPtr<T> &other) = delete;
+    LeasedPtr<T>& operator=(LeasedPtr<T> &&other) = delete;
+
+    // Tries to deposit the `ptr_`, and make it available to the consumer.
+    // Returns empty std::unique_ptr if the pointer was susscessfully deposited.
+    // Returns the original ptr otherwise.
+    std::unique_ptr<T> provision(std::unique_ptr<T> ptr_) noexcept {
+      if (!empty()) {
+	// LeasedPtr holds a different value. Can't store a new pointer.
+	return ptr_;
+      }
+
+      // LeasedPtr is empty and ready to be provisioned.
+      _ptr = std::move(ptr_);
+      _state.store(State::Provisioned, std::memory_order_release);
+      return {};
+    }
+
+    // Indicates if has space for new deposit.
+    bool empty() const noexcept {
+      return _state.load(std::memory_order_relaxed) == State::Dormant;
+    }
+
+    // Producer breaks the lease, and releases the ownership of the pointer and passes it to the consumer.
+    // Returns true on success. Returns false if the consumer hasn't leased the pointer yet - the ownership stays with the producer.
+    std::unique_ptr<T> revoke() noexcept {
+      auto state{State::Provisioned};
+      if (_state.compare_exchange_strong(state, State::Dormant, std::memory_order_release, std::memory_order_acquire)) {
+	return std::move(_ptr);
+      }
+
+      assert ((state == State::Leased) || (state == State::Returned));
+
+      // Someone has borrowed the pointer, we're trying to abandon it
+      if (state == State::Leased && _state.compare_exchange_strong(state, State::Revoked, std::memory_order_release, std::memory_order_acquire)) {
+	return {};
+      }
+
+      if (state == State::Returned && _state.compare_exchange_strong(state, State::Dormant, std::memory_order_release, std::memory_order_acquire)) {
+	return std::move(_ptr);
+      }
+
+      // Should not reach.
+      assert(false);
+      return {};
+    }
+
+    // Attempts to lease the pointer. On success returns the deposited pointer.
+    // Returns nullptr on failure.
+    std::unique_ptr<T> lease() noexcept {
+      auto provisioned{State::Provisioned};
+      auto successfullyLeased = _state.compare_exchange_strong(provisioned, State::Leased,
+							       std::memory_order_release,
+							       std::memory_order_acquire);
+
+      return successfullyLeased ? std::move(_ptr) : std::unique_ptr<T>{};
+    }
+
+    // The consumer returns the pointer back to the producer. If the operation was sucessful, an empty unique_ptr is retruned.
+    // Otherwise, the original pointer is returned.
+    std::unique_ptr<T> returnLease(std::unique_ptr<T> ptr_) noexcept {
+      assert((_state.load(std::memory_order_relaxed) == State::Leased) || _state.load(std::memory_order_relaxed) == State::Revoked);
+
+      _ptr = std::move(ptr_);
+      auto leased{State::Leased};
+      if (_state.compare_exchange_strong(leased, State::Returned, std::memory_order_release, std::memory_order_acquire)) {
+	return {};
+      }
+
+      assert(_state.load(std::memory_order_relaxed) == State::Revoked);
+      ptr_ = std::move(_ptr);
+      _state.store(State::Dormant, std::memory_order_release);
+      return ptr_;
+    }
+  };
+}}

--- a/lib/xpedite/framework/request/ProbeRequest.H
+++ b/lib/xpedite/framework/request/ProbeRequest.H
@@ -13,7 +13,6 @@
 namespace xpedite { namespace framework { namespace request {
 
   struct ProbeListRequest : public Request {
-
     void execute(Handler& handler_) override {
       _response.setValue(handler_.listProbes());
     }
@@ -21,14 +20,16 @@ namespace xpedite { namespace framework { namespace request {
     const char* typeName() const override {
       return "ProbeListRequest";
     }
+
+    std::unique_ptr<Request> clone() const {
+      return std::make_unique<ProbeListRequest>(*this);
+    }
   };
 
   class ProbeActivationRequest : public Request {
-
     std::vector<probes::ProbeKey> _keys;
 
-    public:
-    
+  public:
     ProbeActivationRequest(std::vector<probes::ProbeKey> keys_)
       : _keys {std::move(keys_)} {
     }
@@ -43,14 +44,16 @@ namespace xpedite { namespace framework { namespace request {
     const char* typeName() const override {
       return "ProbeActivationRequest";
     }
+
+    std::unique_ptr<Request> clone() const {
+      return std::make_unique<ProbeActivationRequest>(*this);
+    }
   };
 
   class ProbeDeactivationRequest : public Request {
-
     std::vector<probes::ProbeKey> _keys;
 
-    public:
-    
+  public:
     ProbeDeactivationRequest(std::vector<probes::ProbeKey> keys_)
       : _keys {std::move(keys_)} {
     }
@@ -64,6 +67,10 @@ namespace xpedite { namespace framework { namespace request {
 
     const char* typeName() const override {
       return "ProbeDeactivationRequest";
+    }
+
+    std::unique_ptr<Request> clone() const {
+      return std::make_unique<ProbeDeactivationRequest>(*this);
     }
   };
 

--- a/lib/xpedite/framework/request/ProfileRequest.H
+++ b/lib/xpedite/framework/request/ProfileRequest.H
@@ -17,7 +17,6 @@
 namespace xpedite { namespace framework { namespace request {
 
   class ProfileActivationRequest : public Request {
-
     std::string _samplesFilePattern;
     MilliSeconds _pollInterval;
     uint64_t _samplesDataCapacity;
@@ -25,8 +24,7 @@ namespace xpedite { namespace framework { namespace request {
     XpediteRecorder _recorder;
     XpediteDataProbeRecorder _dataProbeRecorder;
 
-    public:
-
+  public:
     ProfileActivationRequest(std::string samplesFilePattern_, MilliSeconds pollInterval_, uint64_t samplesDataCapacity_)
       : _samplesFilePattern {std::move(samplesFilePattern_)}, _pollInterval {pollInterval_},
         _samplesDataCapacity {samplesDataCapacity_}, _recorder {}, _dataProbeRecorder {} {
@@ -57,10 +55,13 @@ namespace xpedite { namespace framework { namespace request {
     const char* typeName() const override {
       return "ProfileActivationRequest";
     }
+
+    std::unique_ptr<Request> clone() const {
+      return std::make_unique<ProfileActivationRequest>(*this);
+    }
   };
 
   struct ProfileDeactivationRequest : public Request {
-
     void execute(Handler& handler_) override {
       auto rc = handler_.endProfile();
       if(rc.empty()) {
@@ -74,14 +75,17 @@ namespace xpedite { namespace framework { namespace request {
     const char* typeName() const override {
       return "ProfileDeactivationRequest";
     }
+
+    std::unique_ptr<Request> clone() const {
+      return std::make_unique<ProfileDeactivationRequest>(*this);
+    }
   };
 
   class PmuActivationRequest : public Request {
     int _gpEventsCount;
     std::vector<int> _fixedEventIndices;
 
-    public:
-
+  public:
     PmuActivationRequest(int gpEventsCount_, std::vector<int> fixedEventIndices_)
       : _gpEventsCount {gpEventsCount_}, _fixedEventIndices {std::move(fixedEventIndices_)} {
     }
@@ -97,14 +101,16 @@ namespace xpedite { namespace framework { namespace request {
     const char* typeName() const override {
       return "PmuActivationRequest";
     }
+
+    std::unique_ptr<Request> clone() const {
+      return std::make_unique<PmuActivationRequest>(*this);
+    }
   };
 
   class PerfEventsActivationRequest : public Request {
-
     PMUCtlRequest _request;
 
     public:
-
     PerfEventsActivationRequest(const PMUCtlRequest& request_)
       : _request {request_} {
     }
@@ -121,6 +127,10 @@ namespace xpedite { namespace framework { namespace request {
     const char* typeName() const override {
       return "PerfEventsActivationRequest";
     }
+
+    std::unique_ptr<Request> clone() const {
+      return std::make_unique<PerfEventsActivationRequest>(*this);
+    }
   };
 
   struct PmuDeactivationRequest : public Request {
@@ -131,6 +141,10 @@ namespace xpedite { namespace framework { namespace request {
 
     const char* typeName() const override {
       return "PmuDeactivationRequest";
+    }
+
+    std::unique_ptr<Request> clone() const {
+      return std::make_unique<PmuDeactivationRequest>(*this);
     }
   };
 

--- a/lib/xpedite/framework/request/Request.H
+++ b/lib/xpedite/framework/request/Request.H
@@ -24,8 +24,7 @@ namespace xpedite { namespace framework { namespace request {
   {
     std::string _value;
 
-    public:
-
+  public:
     void setValue(std::string value_) {
       _value = std::move(value_);
       _status = Status::SUCCESS;
@@ -37,9 +36,7 @@ namespace xpedite { namespace framework { namespace request {
   };
 
   class Request : public AbstractRequest {
-
-    protected:
-
+  protected:
     Response _response;
 
     static std::string toString(Status status_);
@@ -50,7 +47,8 @@ namespace xpedite { namespace framework { namespace request {
       return "Request";
     }
 
-    public:
+  public:
+    virtual std::unique_ptr<Request> clone() const = 0;
 
     const Response& response() const override {
       return _response;
@@ -66,7 +64,6 @@ namespace xpedite { namespace framework { namespace request {
   };
 
   struct PingRequest : public Request {
-
     void execute(Handler& handler_) override {
       _response.setValue(handler_.ping());
     }
@@ -75,10 +72,12 @@ namespace xpedite { namespace framework { namespace request {
       return "PingRequest";
     }
 
+    std::unique_ptr<Request> clone() const override {
+      return std::make_unique<PingRequest>(*this);
+    }
   };
 
   struct TscRequest : public Request {
-
     void execute(Handler& handler_) override {
       auto tscHz = handler_.tscHz();
       _response.setValue(std::to_string(tscHz));
@@ -88,14 +87,15 @@ namespace xpedite { namespace framework { namespace request {
       return "TscRequest";
     }
 
+    std::unique_ptr<Request> clone() const override{
+      return std::make_unique<TscRequest>(*this);
+    }
   };
 
   struct InvalidRequest : public Request {
-
     std::string _errors;
 
-    public:
-
+  public:
     explicit InvalidRequest(std::string errors_)
       : _errors {std::move(errors_)} {
     }
@@ -106,6 +106,10 @@ namespace xpedite { namespace framework { namespace request {
 
     const char* typeName() const override {
       return "InvalidRequest";
+    }
+
+    std::unique_ptr<Request> clone() const override{
+      return std::make_unique<InvalidRequest>(*this);
     }
   };
 

--- a/lib/xpedite/framework/session/LocalSession.H
+++ b/lib/xpedite/framework/session/LocalSession.H
@@ -11,6 +11,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
+#include <xpedite/common/LeasedPtr.H>
 #include <xpedite/util/Allocator.H>
 #include <xpedite/log/Log.H>
 #include <sstream>
@@ -21,7 +22,7 @@ namespace xpedite { namespace framework { namespace session {
 
   class LocalSession : public util::AlignedObject<XPEDITE_CACHELINE_SIZE>
   {
-    std::atomic<request::Request*> _request;
+    common::LeasedPtr<request::Request> _request;
 
     alignas(XPEDITE_CACHELINE_SIZE) Handler& _handler;
 
@@ -34,28 +35,34 @@ namespace xpedite { namespace framework { namespace session {
       return elapsed_ > duration_;
     }
 
-    public:
-
+  public:
     LocalSession(Handler& handler_)
       : _request {}, _handler (handler_), _isAlive {} {
     }
 
     bool execute(request::Request* request_, MilliSeconds timeout_) {
       MilliSeconds elapsed {0};
+      auto request = request_->clone();
       // enque request
       while(!hasTimedOut(timeout_, elapsed)) {
-        request::Request* expected = {};
-        if(_request.compare_exchange_weak(expected, request_, std::memory_order_release, std::memory_order_relaxed)) {
-          break;
-        }
+	request = std::move(_request.provision(std::move(request)));
+	if (!request) {
+	  break;
+	}
+
         std::this_thread::sleep_for(_handler.pollInterval());
         elapsed += _handler.pollInterval();
       }
       
       // await execution
-      while(!hasTimedOut(timeout_, elapsed) && _request.load(std::memory_order_acquire) == request_) {
+      while(!hasTimedOut(timeout_, elapsed) && !_request.empty()) {
         std::this_thread::sleep_for(_handler.pollInterval());
         elapsed += _handler.pollInterval();
+      }
+
+      const auto releasedRequest = _request.revoke();
+      if (releasedRequest) {
+	request_->response() = std::move(request->response());
       }
 
       if(hasTimedOut(timeout_, elapsed)) {
@@ -73,14 +80,14 @@ namespace xpedite { namespace framework { namespace session {
     }
 
     bool poll(bool canAcceptRequest_) {
-      if(auto* request = _request.load(std::memory_order_acquire)) {
+      if(auto request = _request.lease()) {
         if(canAcceptRequest_) {
           request->execute(_handler);
           _isAlive = true;
         } else {
           request->abort("xpedite dectected active session - multiple sessions not supported");
         }
-        _request.store(nullptr, std::memory_order_release);
+	_request.returnLease(std::move(request));
       }
       return isAlive();
     }

--- a/lib/xpedite/framework/session/SessionManager.H
+++ b/lib/xpedite/framework/session/SessionManager.H
@@ -37,7 +37,6 @@ namespace xpedite { namespace framework { namespace session {
     bool _isAlive;
 
     public:
-
     SessionManager()
       : _handler {}, _localSession {new LocalSession {_handler}}, _remoteSession {},
         _sessionType {DORMANT}, _isAlive {} {
@@ -98,9 +97,8 @@ namespace xpedite { namespace framework { namespace session {
       }
     }
 
-    bool execute(request::Request* request_) {
-      //hardcoded to no timilimit, as requests are allocated in stack
-      MilliSeconds timeout= MilliSeconds {0};
+    bool execute(request::Request *request_) {
+      MilliSeconds timeout= MilliSeconds {100};
       return _localSession->execute(request_, timeout);
     }
 

--- a/test/gtest/LeasedPtr.C
+++ b/test/gtest/LeasedPtr.C
@@ -1,0 +1,124 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Xpedite test for LeasedPtr.
+//
+// Author: Marcin Dlugajczyk, Morgan Stanley
+//
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+
+#include <xpedite/common/LeasedPtr.H>
+#include <gtest/gtest.h>
+
+using LeasedPtr = xpedite::common::LeasedPtr<int>;
+struct LeasedPtrTest : ::testing::Test
+{
+};
+
+TEST_F(LeasedPtrTest, StoreValueInEmptyLeasedPtr) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)).get(), nullptr);
+}
+
+
+TEST_F(LeasedPtrTest, CantStoreIntoOccupiedLeasedPtr) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+  auto value2{std::make_unique<int>(43)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)), nullptr);
+  auto failedProvision = leasedPtr.provision(std::move(value2));
+  ASSERT_EQ(*failedProvision, 43);
+}
+
+
+TEST_F(LeasedPtrTest, CantLeaseFromEmptyLeasedPtr) {
+  LeasedPtr leasedPtr{};
+
+  ASSERT_EQ(leasedPtr.lease(), nullptr);
+}
+
+TEST_F(LeasedPtrTest, CanLeaseFromOccupiedLeasedPtr) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)), nullptr);
+  ASSERT_EQ(*leasedPtr.lease(), 42);
+}
+
+TEST_F(LeasedPtrTest, CantLeaseTwice) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)), nullptr);
+  ASSERT_EQ(*leasedPtr.lease(), 42);
+  ASSERT_EQ(leasedPtr.lease(), nullptr);
+}
+
+TEST_F(LeasedPtrTest, CantStoreIfCurrentValueIsLeaseed) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+  auto value2{std::make_unique<int>(43)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)), nullptr);
+  ASSERT_EQ(*leasedPtr.lease(), 42);
+  ASSERT_EQ(*leasedPtr.provision(std::move(value2)), 43);
+}
+
+TEST_F(LeasedPtrTest, HasntBeenConsumedIfStored) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)), nullptr);
+  ASSERT_FALSE(leasedPtr.empty());
+}
+
+TEST_F(LeasedPtrTest, IsntEmptyIfLeaseReturned) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)), nullptr);
+  leasedPtr.lease();
+  ASSERT_FALSE(leasedPtr.empty());
+}
+
+TEST_F(LeasedPtrTest, CanReturnAfterLease) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)), nullptr);
+  auto leased = leasedPtr.lease();
+  ASSERT_EQ(leasedPtr.returnLease(std::move(leased)), nullptr);
+}
+
+TEST_F(LeasedPtrTest, CantReturnIfRevoked) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  ASSERT_EQ(leasedPtr.provision(std::move(value)), nullptr);
+  auto leased = leasedPtr.lease();
+  leasedPtr.revoke();
+  auto notReleased = leasedPtr.returnLease(std::move(leased));
+  ASSERT_NE(notReleased, nullptr);
+  ASSERT_EQ(*notReleased, 42);
+}
+
+TEST_F(LeasedPtrTest, CantReleaseOwnershiIfNotLeased) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  leasedPtr.provision(std::move(value));
+  auto revokeResult = leasedPtr.revoke();
+  ASSERT_EQ(*revokeResult, 42);
+}
+
+TEST_F(LeasedPtrTest, CanReleaseOwnershiIfLeaseed) {
+  LeasedPtr leasedPtr{};
+  auto value{std::make_unique<int>(42)};
+
+  leasedPtr.provision(std::move(value));
+  auto leased = leasedPtr.lease();
+  ASSERT_EQ(leasedPtr.revoke(), nullptr);
+}


### PR DESCRIPTION
By creating the request to the local session on the heap,
rather than on the stack we can time it out without the risk of the
background thread accessing a request object that has been
deallocated.

To ensure correct ownership a new data structure is introduced -
a wait free escrow.

Local requests cannot be issued concurrently.