### PR TITLE
Use apt add-on for updating Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ branches:
   only:
   - master
 
-before_script:
- - sudo apt-get -qq update
+before_install:
  - sudo apt-get install -y libgtest-dev cmake
+addons:
+  apt:
+    update: true
+
+before_script:
  - sudo wget https://github.com/google/googletest/archive/release-1.7.0.tar.gz
  - sudo tar xf release-1.7.0.tar.gz
  - pushd googletest-release-1.7.0


### PR DESCRIPTION
https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
to fix CI job error: 
The command "sudo apt-get -qq update" failed and exited with 100 during .