### PR TITLE
Shallow-copy OrderedDict for iteration while filtering transactions to avoid a runtime error regarding modifications during iteration

### DIFF
--- a/scripts/lib/xpedite/analytics/__init__.py
+++ b/scripts/lib/xpedite/analytics/__init__.py
@@ -188,7 +188,7 @@ class Analytics(object):
       txnMap = txnCollection.txnMap
       filteredCount = 0
       unfilteredCount = len(txnMap)
-      for tid, txn in txnMap.items():
+      for tid, txn in txnMap.copy().items():
         if not txnFilter(txnCollection.name, txn):
           del txnMap[tid]
           filteredCount += 1


### PR DESCRIPTION
Addresses issue #163 