### PR TITLE
Mark the stack as noexec in asm files

### DIFF
--- a/dco/alexandros-tasos.md
+++ b/dco/alexandros-tasos.md
@@ -1,0 +1,79 @@
+DEVELOPER CERTIFICATE OF ORIGIN
+===============================
+
+Thank you for your interest in the open source software project(s) (the “Project”) maintained or managed by
+Morgan Stanley Services Group Inc. (“us” or “we”). The purpose of this Developer Certificate of Origin (the “DCO” or
+“Agreement”) is to define the intellectual property license granted by persons or entities that make Contributions
+(defined below) to the Project. You, Alexandros Tasos, agree and certify as set forth in this Agreement. You may be
+contacted at [the following email address](https://spamty.eu/show/v7/215/a6645e7b46/).
+
+By submitting a Contribution, including but not limited to by pull request, you agree that you have read and
+understood this Agreement and you will be legally bound thereby.  In consideration of the opportunity to
+participate in the community of Project contributors, you hereby agree to the following terms and conditions in
+connection with your present and future Contributions:
+
+1. **Contributions:**
+
+ * The term “Contribution” means any source code, object code, patch, tool, sample, graphic, specification, manual,
+   documentation, or any other material submitted by you to the Project.
+ * A Contribution is “submitted” when any form of electronic, verbal, or written communication is sent to the Project,
+   including but not limited to communication on electronic mailing lists, source code control systems,and issue
+   tracking systems that are managed by, or on behalf of, the Project for the purpose of discussing or improving
+   software or documentation of the Project (“Communication”).
+ * Each Communication that is conspicuously marked or designated by you in writing as “Not a Contribution” will
+   not be considered a Contribution.
+ * Any Contribution submitted by you to the Project will be under the terms and conditions of this Agreement
+   without any additional terms or conditions.
+
+2. **Grant of License:** You hereby grant us and our affiliates, for purposes of the Project, and to recipients of
+software distributed by the Project:
+
+ * a perpetual, irrevocable, non-exclusive, worldwide, fully paid-up, royalty-free, unrestricted license to
+   exercise all rights (including sublicensing and commercial exploitation) under all worldwide copyrights,
+   copyright applications and registrations in the Contribution; and
+ * a perpetual, irrevocable, non-exclusive, worldwide, full paid-up, royalty-free patent license to make, have
+   made, use, offer to sell, sell, import, and otherwise transfer your Contribution and derivative works thereof,
+   where such license applies only to those patent claims licensable by you or your affiliates that are necessarily
+   infringed by your Contribution alone or by combination of your Contribution with the Project to which you
+   submitted the Contribution.
+
+3. **Ownership:**
+
+ * Except as set out above, you keep all right, title and interest in your Contribution.
+ * You represent that:
+
+  * you are the owner of the Contribution or are otherwise legally entitled to grant the above licenses;
+  * if any third party, including your employer and/or its affiliates, has rights to any intellectual property
+    included in your Contribution, then (i) each such third party has provided you written permission to make the
+    Contribution as specified herein or a written waiver of such rights in and to your
+    Contribution, and (ii) such third party(ies) is/are Alexandros Tasos;
+  * your Contribution is an original work created by you, and except for third parties who have given permission
+    to make the Contribution as set forth above, to your knowledge, no other person or entity has claimed,
+    claims, or has the right to claim any right whatsoever in the Contribution; and
+  * your Contribution includes complete details of any third party license(s) or other restriction(s)
+    (including, but not limited to, related copyrights, patents and trademarks) of which you are aware and
+    which are associated with any part of your Contribution, and of all matters required to be disclosed under
+    such third party licenses (such as all applicable copyright, patent, trademark and attribution notices,
+    and all modifications made to certain open source software).
+
+4. **Notice; Inclusion; No Confidentiality:**
+
+ * You agree to notify us of any facts or circumstances of which you become aware that would make these
+   representations inaccurate in any respect. Notices and other communications to be sent as directed in the
+   applicable Project
+ * Neither we nor the Project is under any obligation to accept and include your Contribution, or to return it to you.
+ * You will not, absent a separate written agreement signed by us, impose any confidentiality obligations on us,
+   and we have not undertaken any obligation to treat any Contributions or other information you have or will
+   give us as confidential or proprietary information.
+ * You understand and agree that all Contributions including all personal information you submit with it may be
+   maintained indefinitely and may be redistributed consistent with the applicable open source license(s).
+
+5. **Effective Date:** The rights that you grant to us under these terms are effective on the date you first
+submit a Contribution to us, even if your submission took place before the date you accept the terms of this Agreement.
+
+6. **Governing Law; Entire Agreement:** This Agreement is governed by the laws of the State of New York,
+without regard to its choice of law provisions, and by the laws of the United States.  This Agreement sets
+forth the entire understanding and agreement between the parties, and supersedes any previous communications,
+representations or agreements, whether oral or written, regarding the subject matter herein.  No alteration, waiver,
+amendment, change or supplement hereto shall be binding or effective unless the same is set forth in writing
+signed by both parties. We may freely assign our rights or obligations under this Agreement.

--- a/lib/xpedite/probes/DataProbeCtl.S
+++ b/lib/xpedite/probes/DataProbeCtl.S
@@ -16,6 +16,8 @@
 
 #include <xpedite/probes/StackAlign.H>
 
+.section .note.GNU-stack,"",@progbits
+
 .section .text
 .global  xpediteDataProbeTrampoline
 .type xpediteDataProbeTrampoline, @function 

--- a/lib/xpedite/probes/IdentityProbeCtl.S
+++ b/lib/xpedite/probes/IdentityProbeCtl.S
@@ -16,6 +16,8 @@
 
 #include <xpedite/probes/StackAlign.H>
 
+.section .note.GNU-stack,"",@progbits
+
 .section .text
 .global  xpediteIdentityTrampoline
 .type xpediteIdentityTrampoline, @function 

--- a/lib/xpedite/probes/ProbeCtl.S
+++ b/lib/xpedite/probes/ProbeCtl.S
@@ -16,6 +16,8 @@
 
 #include <xpedite/probes/StackAlign.H>
 
+.section .note.GNU-stack,"",@progbits
+
 .section .text
 
 .global  xpediteTrampoline


### PR DESCRIPTION
A missing `.note.GNU-stack` section implicitly marks the stack as `PROT_EXEC`:

```
warning: ProbeCtl.o: missing .note.GNU-stack section implies executable stack
NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```

AFAICT, Xpedite doesn't rely on an executable stack, so we can explicitly mark it as noexec.

**EDIT**: Covered by `dco/alexandros-tasos.md`